### PR TITLE
Add homepage to deb package info

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-iec104 (1.1.1) stable; urgency=medium
+
+  * Add homepage to deb package info. No functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 25 Jul 2023 16:34:00 +0400
+
 wb-mqtt-iec104 (1.1.0) stable; urgency=medium
 
   * Add support for values with timestamp: M_SP_TB_1, M_ME_TF_1, M_ME_TE_1.

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-4-dev, libwbmqtt1-4-test-utils
+Homepage: https://github.com/wirenboard/wb-mqtt-iec104
 
 Package: wb-mqtt-iec104
 Architecture: any


### PR DESCRIPTION
`wbci-changelog` uses `Homepage` from `deb/control`:

<img width="867" alt="Näyttökuva 2023-7-25 kello 18 12 16" src="https://github.com/wirenboard/wb-mqtt-iec104/assets/688044/eaec14d3-b23a-48d8-bf88-9700430cecf5">
