### PR TITLE
fix empty config handling after previous update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-iec104 (1.1.10) stable; urgency=medium
+
+  * Fix empty config handling after previous update
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Thu, 22 Aug 2024 12:29:19 +0500
+
 wb-mqtt-iec104 (1.1.9) stable; urgency=medium
 
   * Do not restart service on config file error

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -231,6 +231,8 @@ TConfig LoadConfig(const std::string& configFileName, const std::string& configS
         cfg.Devices = LoadGroups(config, usedAddresses);
         Get(config, "debug", cfg.Debug);
         return cfg;
+    } catch (const TEmptyConfigException& e) {
+        throw;
     } catch (const std::exception& e) {
         throw TConfigException(e.what());
     }


### PR DESCRIPTION
сломал в #18 то, что делал в #17 