### PR TITLE
Add coverage report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ compile_commands.json
 # Visual Studio Code
 .vscode
 .clang-format
+.devcontainer
 
 ### direnv ###
 .direnv

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '61'
+               defaultCoverageMin: '52'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: 'src test'
-
+               defaultStyleCheckDirs: 'src test',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '61'

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,6 @@ LDFLAGS = -lwbmqtt1 -lpthread
 CXXFLAGS = -std=c++17 -Wall -Werror $(LIB60870_INCLUDES) -I$(SRC_DIR)
 CFLAGS = -Wall $(LIB60870_INCLUDES) -I$(SRC_DIR)
 
-DEBUG=
-NDEBUG?=y
-ifeq ($(NDEBUG),)
-DEBUG=y
-endif
-
 CXXFLAGS += $(if $(or $(DEBUG)),$(DEBUG_CXXFLAGS),$(NORMAL_CXXFLAGS))
 LDFLAGS += $(if $(or $(DEBUG)),$(DEBUG_LDFLAGS),$(NORMAL_LDFLAGS))
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= cov.html
-GCOVR_FLAGS := --html $(COV_REPORT)
+GCOVR_FLAGS := -s --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
-COV_REPORT ?= cov.html
-GCOVR_FLAGS := -s --html $(COV_REPORT)
+COV_REPORT ?= cov
+GCOVR_FLAGS := -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,24 @@ LIB60870_DIR = thirdparty/lib60870/lib60870-C/src
 
 COMMON_OBJS = log.o config_parser.o gateway.o IEC104Server.o iec104_exception.o
 
-DEBUG_CXXFLAGS = -O0 -fprofile-arcs -ftest-coverage
-DEBUG_LDFLAGS = -lgcov
+DEBUG_CXXFLAGS = -O0 --coverage
+DEBUG_LDFLAGS = --coverage
 
-NORMAL_CXXFLAGS = -O2 -I$(SRC_DIR)
+NORMAL_CXXFLAGS = -O2
 NORMAL_LDFLAGS =
 
 TEST_DIR = test
 TEST_OBJS = main.o config.test.o gateway.test.o
 TEST_TARGET = test-app
 TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
+
+VALGRIND_FLAGS = --error-exitcode=180 -q
+
+COV_REPORT ?= cov.html
+GCOVR_FLAGS := --html $(COV_REPORT)
+ifneq ($(COV_FAIL_UNDER),)
+	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
+endif
 
 TEST_OBJS := $(patsubst %, $(TEST_DIR)/%, $(TEST_OBJS))
 COMMON_OBJS := $(patsubst %, $(SRC_DIR)/%, $(COMMON_OBJS))
@@ -57,7 +65,7 @@ COMMON_OBJS += $(LIB60870_OBJS)
 LIB60870_INCLUDES = -I$(LIB60870_DIR)/inc/api -I$(LIB60870_DIR)/inc/internal -I$(LIB60870_DIR)/common/inc -I$(LIB60870_DIR)/hal/inc
 
 LDFLAGS = -lwbmqtt1 -lpthread
-CXXFLAGS = -std=c++17 -Wall -Werror $(LIB60870_INCLUDES)
+CXXFLAGS = -std=c++17 -Wall -Werror $(LIB60870_INCLUDES) -I$(SRC_DIR)
 CFLAGS = -Wall $(LIB60870_INCLUDES) -I$(SRC_DIR)
 
 DEBUG=
@@ -91,7 +99,7 @@ test/%.o: test/%.cpp
 
 test: $(TEST_DIR)/$(TEST_TARGET)
 	if [ "$(shell arch)" != "armv7l" ] && [ "$(CROSS_COMPILE)" = "" ] || [ "$(CROSS_COMPILE)" = "x86_64-linux-gnu-" ]; then \
-		valgrind --error-exitcode=180 -q $(TEST_DIR)/$(TEST_TARGET) || \
+		valgrind $(VALGRIND_FLAGS) -q $(TEST_DIR)/$(TEST_TARGET) || \
 		if [ $$? = 180 ]; then \
 			echo "*** VALGRIND DETECTED ERRORS ***" 1>& 2; \
 			exit 1; \
@@ -99,6 +107,9 @@ test: $(TEST_DIR)/$(TEST_TARGET)
 	else \
 		$(TEST_DIR)/$(TEST_TARGET); \
 	fi
+ifneq ($(DEBUG),)
+	gcovr $(GCOVR_FLAGS) $(SRC_DIR) $(TEST_DIR)
+endif
 
 $(TEST_DIR)/$(TEST_TARGET): $(TEST_OBJS) $(COMMON_OBJS)
 	$(CXX) -o $@ $^ $(LDFLAGS) $(TEST_LDFLAGS) -fno-lto

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-iec104 (1.1.12) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-iec104 (1.1.11) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-5. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,12 @@ Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 4.5.1
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-5-dev, libwbmqtt1-5-test-utils, libgtest-dev
+Build-Depends: debhelper (>= 10),
+               gcovr:all,
+               libgtest-dev,
+               libwbmqtt1-5-dev,
+               libwbmqtt1-5-test-utils,
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-iec104
 
 Package: wb-mqtt-iec104

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,18 @@
 #!/usr/bin/make -f
 
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=61 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-10-1 kello 3 33 23" src="https://github.com/user-attachments/assets/de289e5d-5243-406a-83e3-54de1b9d7040">
