### PR TITLE
Add option to prevent groups update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ compile_commands.json
 
 # Visual Studio Code
 .vscode
-.clang-format
+.clang-*
 .devcontainer
 
 ### direnv ###

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-iec104 (1.2.0) stable; urgency=medium
+
+  * Add option to prevent groups update
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 02 Mar 2026 12:00:00 +0400
+
 wb-mqtt-iec104 (1.1.15) stable; urgency=medium
 
   * Remove system MQTT controls from config

--- a/src/IEC104Server.cpp
+++ b/src/IEC104Server.cpp
@@ -306,7 +306,7 @@ namespace
 
     void TServerImpl::HandleInterrogationRequest(IMasterConnection connection, CS101_ASDU incomimgAsdu, int qoi)
     {
-        if (qoi == 20) { /* only handle station interrogation */
+        if (qoi == IEC60870_QOI_STATION) { /* only handle station interrogation */
             IMasterConnection_sendACT_CON(connection, incomimgAsdu, false);
 
             Send(AppLayerParameters,

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -244,14 +244,20 @@ void UpdateConfig(const string& configFileName, const string& configSchemaFileNa
     auto config = JSON::Parse(configFileName);
     JSON::Validate(config, JSON::Parse(configSchemaFileName));
 
-    WBMQTT::TMosquittoMqttConfig mqttConfig(LoadMqttConfig(config));
-    mqttConfig.Id = id;
-    auto mqtt = NewMosquittoMqttClient(mqttConfig);
-    auto backend = NewDriverBackend(mqtt);
-    auto driver = NewDriver(TDriverArgs{}.SetId(id).SetBackend(backend));
-    driver->StartLoop();
-    UpdateConfig(driver, config);
-    driver->StopLoop();
+    bool update_groups = false;
+    Get(config, "update_groups", update_groups);
+    if (update_groups) {
+        WBMQTT::TMosquittoMqttConfig mqttConfig(LoadMqttConfig(config));
+        mqttConfig.Id = id;
+        auto mqtt = NewMosquittoMqttClient(mqttConfig);
+        auto backend = NewDriverBackend(mqtt);
+        auto driver = NewDriver(TDriverArgs{}.SetId(id).SetBackend(backend));
+        driver->StartLoop();
+        UpdateConfig(driver, config);
+        driver->StopLoop();
+    }
+
+    config["update_groups"] = false;
 
     Json::StreamWriterBuilder builder;
     builder["indentation"] = "    ";

--- a/wb-mqtt-iec104.sample.conf
+++ b/wb-mqtt-iec104.sample.conf
@@ -1,5 +1,6 @@
 {
     "debug": false,
+    "update_groups": true,
     "iec104": {
         "host": "",
         "port": 2404,

--- a/wb-mqtt-iec104.schema.json
+++ b/wb-mqtt-iec104.schema.json
@@ -21,6 +21,7 @@
           "type": "string",
           "title": "MQTT device and control (from topic name)",
           "propertyOrder": 2,
+          "readonly": true,
           "options": {
               "wb": {
                   "data": "devices"
@@ -31,7 +32,8 @@
         "info": {
           "type": "string",
           "title": "For information only",
-          "propertyOrder": 3
+          "propertyOrder": 3,
+          "readonly": true
         },
         "address": {
           "type": "integer",
@@ -80,7 +82,8 @@
         "name": {
           "type": "string",
           "title": "Group name",
-          "propertyOrder": 1
+          "propertyOrder": 1,
+          "readonly": true
         },
         "controls": {
           "type": "array",
@@ -94,6 +97,7 @@
             "disable_array_reorder": true,
             "disable_array_delete_last_row": true,
             "disable_array_delete_all_rows": true,
+            "disable_array_add": true,
             "disable_collapse": true,
             "compact": true,
             "wb": {
@@ -114,12 +118,20 @@
     }
   },
   "properties": {
+    "update_groups": {
+      "type": "boolean",
+      "title": "Update groups list",
+      "description": "update_groups_description",
+      "default": false,
+      "_format": "checkbox",
+      "propertyOrder": 1
+    },
     "debug": {
       "type": "boolean",
       "title": "Enable debug logging",
       "default": false,
       "_format": "checkbox",
-      "propertyOrder": 1
+      "propertyOrder": 2
     },
     "mqtt": {
       "type": "object",
@@ -165,7 +177,7 @@
         }
       },
       "required": ["host", "port"],
-      "propertyOrder": 2,
+      "propertyOrder": 3,
       "options" : {
         "disable_edit_json" : true,
         "disable_collapse" : true
@@ -198,7 +210,7 @@
           "propertyOrder": 3
         }
       },
-      "propertyOrder": 3,
+      "propertyOrder": 4,
       "required": ["host", "port", "address"],
       "options" : {
         "disable_edit_json" : true,
@@ -209,7 +221,7 @@
     "groups": {
       "type": "array",
       "title": "Groups of controls",
-      "propertyOrder": 4,
+      "propertyOrder": 5,
       "items": {
         "$ref": "#/definitions/group"
       },
@@ -217,6 +229,7 @@
         "disable_array_reorder": true,
         "disable_array_delete_last_row": true,
         "disable_array_delete_all_rows": true,
+        "disable_array_add": true,
         "disable_collapse": true
       },
       "_format": "tabs"
@@ -230,10 +243,13 @@
   },
   "translations": {
     "en": {
+      "update_groups_description": "This flag will be cleared on next start of daemon",
       "service_title": "MQTT to IEC 60870-5-104 gateway",
       "host_desc": "Local IP address to bind gateway to. If empty, gateway will listen to all local IP addresses"
     },
     "ru": {
+      "Update groups list": "Обновить список групп",
+      "update_groups_description": "Опция будет сброшена при следующем запуске сервиса",
       "service_title": "Шлюз MQTT - МЭК 60870-5-104",
       "Control": "Параметр",
       "Send": "Отправлять",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Аналогично https://github.com/wirenboard/wb-mqtt-opcua/pull/34, с той разницей, что в mqtt-iec104 группировка далее в логике никак не используется, только для отображения в UI.

* добавлена опция update_groups, что позволяет не обновлять список групп при каждом рестарте
* имя группы и контролы - readonly
* можно только удалять группы и контролы
* добавление групп и контролов происходит только автоматически при выставлении update_groups=true

___________________________________
**Что поменялось для пользователей:**
<img width="1593" height="616" alt="Screen Shot 2026-03-02 at 15 52 01" src="https://github.com/user-attachments/assets/e4379a78-e778-4364-a5e8-32045cedfb9e" />

___________________________________
**Как проверял/а:**
на вб

